### PR TITLE
[TRI-7] Add prev/next icons to mobile image view

### DIFF
--- a/artist/delta/assets/main.css
+++ b/artist/delta/assets/main.css
@@ -318,6 +318,32 @@ main {
   font-size: 0.75rem;
 }
 
+.image-container {
+  position: relative;
+  max-width: 800px;
+  min-height: 100px;
+}
+
+.feather-minus-circle, .feather-plus-circle {
+  display: none;
+}
+
+@media all and (max-width: 768px) {
+  .feather-minus-circle {
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 0.5rem;
+  }
+
+  .feather-plus-circle {
+    display: block;
+    position: absolute;
+    top: 50%;
+    right: 0.5rem;
+  }
+}
+
 /*************** PASSWORD ****************/
 .password {
   text-align: center;
@@ -357,6 +383,12 @@ main {
   width: 100%;
   box-sizing: border-box;
   padding-left: 1%;
+}
+
+@media all and (max-width: 768px) {
+  .pagination {
+    display: none;
+  }
 }
 
 ul.pages {

--- a/artist/delta/works/show.liquid
+++ b/artist/delta/works/show.liquid
@@ -8,7 +8,19 @@
       {% video_embed('large') %}
     {% endif %}
   {% else %}
-    {{ image | responsive_image_xlarge }}
+    <div class="image-container">
+      {{ image | responsive_image_xlarge }}
+      {% if work.previous_work %}
+        <a href="{{ work.previous_work.page_url | escape }}">
+          <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36" fill="none" stroke="#fff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="feather feather-minus-circle"><circle cx="18" cy="18" r="14"></circle><line x1="12" y1="18" x2="24" y2="18"></line></svg>
+        </a>
+      {% endif %}
+      {% if work.next_work %}
+        <a href="{{ work.next_work.page_url | escape }}">
+          <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36" fill="none" stroke="#fff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="feather feather-plus-circle"><circle cx="18" cy="18" r="14"></circle><line x1="18" y1="12" x2="18" y2="24"></line><line x1="12" y1="18" x2="24" y2="18"></line></svg>
+        </a>
+      {% endif %}
+    </div>
   {% endif %}
   <p class="caption">{{ image.caption | textilize_inline }}</p>
 </div>


### PR DESCRIPTION
- Hooks into `Work#previous_work` and `Work#next_work` to conditionally render pagination icons on mobile.
- Pulls in two open-source SVGs found on https://feathericons.com/

Ticket: https://linear.app/tristan-media/issue/TRI-7/use-arrowsswipe-on-mobile-instead-of-numbers-to-move-to-next-or

@bhoggard Thoughts? I wonder if the white stroke color on the icons will get lost over lighter works.

## Screenshot

![Screenshot from 2020-10-12 22-15-09](https://user-images.githubusercontent.com/123595/95807555-788e6800-0cd8-11eb-938b-60384c91bfee.png)

