### PR TITLE
fix: center image and caption within 2/3 column on home page

### DIFF
--- a/artist/delta/assets/main.css
+++ b/artist/delta/assets/main.css
@@ -656,6 +656,13 @@ a.exhibition:hover {
   margin-bottom: 1rem;
 }
 
+.column.two-thirds img {
+  width: 100%;
+  margin: auto;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
 .column > h1,
 .column > h2,
 .column > h3,


### PR DESCRIPTION
closes https://linear.app/tristan-media/issue/TRI-28/homepage-on-desktop-formatting